### PR TITLE
two critical updates

### DIFF
--- a/BasicSchemas/OIMS_base.json
+++ b/BasicSchemas/OIMS_base.json
@@ -62,7 +62,7 @@
         "\\": "<%GTREE 2.0.2 OIMS_Header%>",
         "AttributeName":"OIMS_Header",
         "AttributeDescription":"header section of an OIMS compatible metadata schema",
-        "Datatype": "text",
+        "Datatype": "compound",
         "Status":"required",
         "TypeClass":"compound",
         "Multiple":"FALSE"
@@ -433,7 +433,7 @@
         "Datatype":"compound",
         "Status":"required",
         "TypeClass":"compound",
-        "Multiple":"FALSE",
+        "Multiple":"TRUE",
         "AttributeValueElements": [
             "SchemaName",
             "SchemaDescription",

--- a/BasicSchemas/OIMS_base.json.bak
+++ b/BasicSchemas/OIMS_base.json.bak
@@ -18,7 +18,7 @@
            },
         "FileDescriptors"   : {
             "MetadataName"     :  "OIMS_base",
-            "MetaDataDescription" :"OIMS selfdescribing metadata schema"
+            "MetaDataDescription" :"OIMS selfdescribing metadata schema",
             "MetadataVersion"  : {
                 "CurrentVersion"        : "2.0.0.0",
                 "MetadataVersionStatus" : "development"
@@ -29,7 +29,7 @@
                 "ContactAffiliation"     : {
                     "ContactAffiliationName"     :"International Maize and Wheat Improvement Center",
                     "ContactAffiliationAcronym"  :"CIMMYT"
-                   }
+                   },
                 "ContactIdentifier": [
                    {
                     "IdentifierScheme":"ORCID",
@@ -44,7 +44,7 @@
              ]
            }
        },
-    "Metadata_Content" : [
+    "OIMS_Content" : [
        {
         "\\": [
             "<%GTREE 2 content section of the OIMS selfdescribing metadata schema%>",
@@ -384,16 +384,19 @@
               {
                   "//":"<%GTREE 2.10.6.1 Exact match%>",
                   "VocabularyElementName":"Exact match",
+                  "//":"skos:exactMatch see https://www.w3.org/TR/skos-reference/#mapping"
                   "VocabularyElementDescription":"the ontology terms matches the attribute exactly"
               },
               {
                   "//":"<%GTREE 2.10.6.2 Too general%>",
                   "VocabularyElementName":"too general",
+                  "//":"skos:BroadMatch see https://www.w3.org/TR/skos-reference/#mapping"
                   "VocabularyElementDescription":"the ontology term covers the attribute, but the attribute is more specific than the ontology term"
               },
               {
                   "//":"<%GTREE 2.10.6.3 too specific%>",
                   "VocabularyElementName":"too specific",
+                  "//":"skos:NarrowMatch see https://www.w3.org/TR/skos-reference/#mapping"
                   "VocabularyElementDescription":"the ontology term covers only part of the attribute, the attribute is broader than the ontology term"
               },
               {


### PR DESCRIPTION
(1) The data type of OIMS_header is obviously compound and not text, even though the data type of the the values of the different components tends to be text.
(2) the value for multiple in metadata schema should be TRUE. You can have multiple schemas . The first schema takes precedence over the second schema in case there are terms that are defined multiple times.